### PR TITLE
Remove broken links in mermaid diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,5 @@ graph TD;
     A(Analyzer Tool);
 
     G-->S-->A;
-
-    click G href "generator"
-    click A href "analyzer"
 ```
 


### PR DESCRIPTION
The links don't seem to work properly and alway redirect users to
root paths of github.com, so we are going to get rid of these for now.


Fixes #2