### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-analyzer.yml
+++ b/.github/workflows/ci-analyzer.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: CI-analyzer
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/LM-Development/SigQual/security/code-scanning/1](https://github.com/LM-Development/SigQual/security/code-scanning/1)

To fix the problem, explicitly set the `permissions` block in the workflow file to restrict the `GITHUB_TOKEN` to the minimum required privileges. Since the workflow only checks out code and runs .NET build/test commands (and does not appear to require write access to the repository or any special scopes), the minimal permission of `contents: read` is sufficient. This should be added at the top level of the workflow file (after the `name` and before `on`), so it applies to all jobs in the workflow. No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
