### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-generator.yml
+++ b/.github/workflows/ci-generator.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: CI-generator
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/LM-Development/SigQual/security/code-scanning/2](https://github.com/LM-Development/SigQual/security/code-scanning/2)

To fix the problem, explicitly set the `permissions` block in the workflow file to restrict the `GITHUB_TOKEN` to the minimum required privileges. Since the workflow appears to only check out code and build it (with no evidence of needing write access), the minimal permission required is likely `contents: read`. This can be set at the workflow level (applies to all jobs) or at the job level (applies only to the specific job). The best practice is to add the following at the top level of the workflow file, just after the `name` field and before `on`:

```yaml
permissions:
  contents: read
```

No additional methods, imports, or definitions are needed; this is a YAML configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
